### PR TITLE
add basic MuchResult API with MuchResult::Item handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@ API for managing the results of operations.
 
 ## Usage
 
-TODO: Write code samples and usage instructions here
+
+```ruby
+def perform_some_operation
+  # Do something that could fail by raising an exception.
+  MuchResult.success(value: "it worked!")
+rescue => error
+  MuchResult.failure(exception: error)
+end
+
+result = perform_some_operation
+
+result.success? # => true
+result.failure? # => false
+result.items    # => [<MuchResult::Item ...>]
+result.value    # => "it worked!"
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ result.success? # => true
 result.failure? # => false
 result.items    # => [<MuchResult::Item ...>]
 result.value    # => "it worked!"
+
+result.set(
+  other_value1: "something else 1",
+  other_value2: "something else 2"
+)
+result.other_value1 # => "something else 1"
+result.other_value2 # => "something else 2"
 ```
 
 ## Installation

--- a/lib/much-result.rb
+++ b/lib/much-result.rb
@@ -21,10 +21,12 @@ class MuchResult
 
   attr_reader :description, :backtrace
 
-  def initialize(description: nil, backtrace: caller, **)
+  def initialize(description: nil, backtrace: caller, **kargs)
     @description = description
     @backtrace = backtrace
     @result_items = []
+
+    set(**kargs)
   end
 
   def success?
@@ -38,6 +40,10 @@ class MuchResult
 
   def failure?
     !success?
+  end
+
+  def set(**kargs)
+    @data = ::OpenStruct.new((@data || {}).to_h.merge(**kargs))
   end
 
   def add_item(item)
@@ -61,5 +67,15 @@ class MuchResult
 
   def failure_items
     @failure_items || @result_items.flat_map { |item| item.failure_items }
+  end
+
+  private
+
+  def respond_to_missing?(*args)
+    @data.send(:respond_to_missing?, *args)
+  end
+
+  def method_missing(method, *args, &block)
+    @data.public_send(method, *args, &block)
   end
 end

--- a/lib/much-result.rb
+++ b/lib/much-result.rb
@@ -1,4 +1,65 @@
 require "much-result/version"
+require "much-result/item"
 
-module MuchResult
+class MuchResult
+  SUCCESS = "success".freeze
+  FAILURE = "failure".freeze
+
+  Error = Class.new(StandardError)
+
+  def self.success(backtrace: caller, **kargs)
+    new(backtrace: backtrace, **kargs).tap { |result|
+      result.add_item(MuchResult::Item.success(backtrace: backtrace, **kargs))
+    }
+  end
+
+  def self.failure(backtrace: caller, **kargs)
+    new(backtrace: backtrace, **kargs).tap { |result|
+      result.add_item(MuchResult::Item.failure(backtrace: backtrace, **kargs))
+    }
+  end
+
+  attr_reader :description, :backtrace
+
+  def initialize(description: nil, backtrace: caller, **)
+    @description = description
+    @backtrace = backtrace
+    @result_items = []
+  end
+
+  def success?
+    if @success_predicate.nil?
+      @success_predicate =
+        @result_items.reduce(true) { |acc, item| acc && item.success? }
+    end
+
+    @success_predicate
+  end
+
+  def failure?
+    !success?
+  end
+
+  def add_item(item)
+    @result_items.push(item)
+  end
+
+  def result_exception
+    @result_exception ||=
+      Error.new(description).tap { |exception|
+        exception.set_backtrace(backtrace)
+      }
+  end
+
+  def items
+    @items ||= @result_items.flat_map { |item| item.items }
+  end
+
+  def success_items
+    @success_items || @result_items.flat_map { |item| item.success_items }
+  end
+
+  def failure_items
+    @failure_items || @result_items.flat_map { |item| item.failure_items }
+  end
 end

--- a/lib/much-result.rb
+++ b/lib/much-result.rb
@@ -19,6 +19,14 @@ class MuchResult
     }
   end
 
+  def self.for_boolean(value, backtrace: caller, **kargs)
+    new(backtrace: backtrace, **kargs).tap { |result|
+      result.add_item(
+        MuchResult::Item.for_boolean(value, backtrace: backtrace, **kargs)
+      )
+    }
+  end
+
   attr_reader :description, :backtrace
 
   def initialize(description: nil, backtrace: caller, **kargs)

--- a/lib/much-result/item.rb
+++ b/lib/much-result/item.rb
@@ -10,6 +10,14 @@ class MuchResult::Item < ::OpenStruct
     new(**kargs, result: MuchResult::FAILURE, backtrace: backtrace)
   end
 
+  def self.for_boolean(value, backtrace: caller, **kargs)
+    new(
+      **kargs,
+      result: value ? MuchResult::SUCCESS : MuchResult::FAILURE,
+      backtrace: backtrace
+    )
+  end
+
   def initialize(result: MuchResult::SUCCESS, backtrace: caller, **kargs)
     super(**kargs, result: result, backtrace: backtrace)
   end

--- a/lib/much-result/item.rb
+++ b/lib/much-result/item.rb
@@ -1,0 +1,58 @@
+require "much-result"
+
+class MuchResult; end
+class MuchResult::Item < ::OpenStruct
+  def self.success(backtrace: caller, **kargs)
+    new(**kargs, result: MuchResult::SUCCESS, backtrace: backtrace)
+  end
+
+  def self.failure(backtrace: caller, **kargs)
+    new(**kargs, result: MuchResult::FAILURE, backtrace: backtrace)
+  end
+
+  def initialize(result: MuchResult::SUCCESS, backtrace: caller, **kargs)
+    super(**kargs, result: result, backtrace: backtrace)
+  end
+
+  def success?
+    result == MuchResult::SUCCESS
+  end
+
+  def failure?
+    result == MuchResult::FAILURE
+  end
+
+  def identifier
+    super # Optional
+  end
+
+  def description
+    super # Optional
+  end
+
+  def backtrace
+    super
+  end
+
+  def result_exception
+    @result_exception ||=
+      MuchResult::Error.new(description).tap { |exception|
+        exception.set_backtrace(backtrace)
+      }
+  end
+
+  # For API compatibility with MuchResult
+  def items
+    @items ||= [self]
+  end
+
+  # For API compatibility with MuchResult
+  def success_items
+    @success_items ||= success? ? items : []
+  end
+
+  # For API compatibility with MuchResult
+  def failure_items
+    @failure_items ||= failure? ? items : []
+  end
+end

--- a/lib/much-result/version.rb
+++ b/lib/much-result/version.rb
@@ -1,3 +1,3 @@
-module MuchResult
+class MuchResult
   VERSION = "0.0.1"
 end

--- a/much-result.gemspec
+++ b/much-result.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = "~> 2.5"
 
-  gem.add_development_dependency("assert", ["~> 2.18.2"])
+  gem.add_development_dependency("assert", ["~> 2.18.3"])
 end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -2,4 +2,12 @@ require "assert/factory"
 
 module Factory
   extend Assert::Factory
+
+  def self.value
+    [Factory.integer, Factory.string, Object.new].sample
+  end
+
+  def self.backtrace
+    Factory.integer(3).times.map{ Factory.string }
+  end
 end

--- a/test/unit/item_tests.rb
+++ b/test/unit/item_tests.rb
@@ -1,0 +1,77 @@
+require "assert"
+require "much-result/item"
+
+class MuchResult::Item
+  class UnitTests < Assert::Context
+    desc "MuchResult::Item"
+    subject { unit_class }
+
+    let(:unit_class) { MuchResult::Item }
+
+    let(:identifier1) { Factory.string }
+    let(:description1) { Factory.string }
+    let(:backtrace1) { Factory.backtrace }
+    let(:value1) { Factory.value }
+
+    should have_imeths :success, :failure
+
+    should "build success instances" do
+      item = subject.success
+
+      assert_that(item.result).equals(MuchResult::SUCCESS)
+      assert_that(item.success?).is_true
+      assert_that(item.failure?).is_false
+
+      assert_that(item.items).equals([item])
+      assert_that(item.success_items).equals(item.items)
+      assert_that(item.failure_items).equals([])
+    end
+
+    should "build failure instances" do
+      item = subject.failure
+
+      assert_that(item.result).equals(MuchResult::FAILURE)
+      assert_that(item.success?).is_false
+      assert_that(item.failure?).is_true
+
+      assert_that(item.items).equals([item])
+      assert_that(item.success_items).equals([])
+      assert_that(item.failure_items).equals(item.items)
+    end
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { item1 }
+
+    let(:item1) { unit_class.success }
+
+    should have_imeths :success?, :failure?
+    should have_imeths :identifier, :description, :backtrace, :result_exception
+    should have_imeths :items, :success_items, :failure_items
+
+    should "know its attributes" do
+      assert_that(subject.identifier).is_nil
+      assert_that(subject.description).is_nil
+      assert_that(subject.backtrace).is_not_nil
+      assert_that(subject.backtrace).is_not_empty
+
+      item =
+        unit_class.success(
+          identifier: identifier1,
+          description: description1,
+          backtrace: backtrace1,
+          value: value1
+        )
+      assert_that(item.identifier).equals(identifier1)
+      assert_that(item.description).equals(description1)
+      assert_that(item.backtrace).equals(backtrace1)
+      assert_that(item.value).equals(value1)
+
+      exception = item.result_exception
+      assert_that(exception).is_instance_of(MuchResult::Error)
+      assert_that(exception.message).equals(description1)
+      assert_that(exception.backtrace).equals(backtrace1)
+    end
+  end
+end

--- a/test/unit/much-result_tests.rb
+++ b/test/unit/much-result_tests.rb
@@ -1,0 +1,87 @@
+require "assert"
+require "much-result"
+
+class MuchResult
+  class UnitTests < Assert::Context
+    desc "MuchResult"
+    subject { unit_class }
+
+    setup do
+      Assert.stub_tap_on_call(MuchResult::Item, :success) { |item, call|
+        @success_result = item
+        @success_item_call = call
+      }
+      Assert.stub_tap_on_call(MuchResult::Item, :failure) { |item, call|
+        @failure_result = item
+        @failure_item_call = call
+      }
+    end
+
+    let(:unit_class) { MuchResult }
+
+    let(:identifier1) { Factory.string }
+    let(:description1) { Factory.string }
+    let(:backtrace1) { Factory.backtrace }
+    let(:value1) { Factory.value }
+
+    should have_imeths :success, :failure
+
+    should "build success instances" do
+      result = subject.success
+
+      assert_that(result.success?).is_true
+      assert_that(result.failure?).is_false
+
+      assert_that(result.items).equals([@success_result])
+      assert_that(result.success_items).equals(result.items)
+      assert_that(result.failure_items).equals([])
+    end
+
+    should "build failure instances" do
+      result = subject.failure
+
+      assert_that(result.success?).is_false
+      assert_that(result.failure?).is_true
+
+      assert_that(result.items).equals([@failure_result])
+      assert_that(result.success_items).equals([])
+      assert_that(result.failure_items).equals(result.items)
+    end
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { result1 }
+
+    let(:result1) { unit_class.success }
+
+    should have_imeths :success?, :failure?
+    should have_imeths :description, :backtrace, :result_exception
+    should have_imeths :items, :success_items, :failure_items
+
+    should "know its attributes" do
+      assert_that(subject.description).is_nil
+      assert_that(subject.backtrace).is_not_nil
+      assert_that(subject.backtrace).is_not_empty
+
+      result =
+        unit_class.success(
+          identifier: identifier1,
+          description: description1,
+          backtrace: backtrace1,
+          value: value1
+        )
+      assert_that(result.items.first.identifier).equals(identifier1)
+      assert_that(result.description).equals(description1)
+      assert_that(result.items.first.description).equals(description1)
+      assert_that(result.backtrace).equals(backtrace1)
+      assert_that(result.items.first.backtrace).equals(backtrace1)
+      assert_that(result.items.first.value).equals(value1)
+
+      exception = result.result_exception
+      assert_that(exception).is_instance_of(MuchResult::Error)
+      assert_that(exception.message).equals(description1)
+      assert_that(exception.backtrace).equals(backtrace1)
+    end
+  end
+end

--- a/test/unit/much-result_tests.rb
+++ b/test/unit/much-result_tests.rb
@@ -47,6 +47,16 @@ class MuchResult
       assert_that(result.success_items).equals([])
       assert_that(result.failure_items).equals(result.items)
     end
+
+    should "build instances based on a Boolean result" do
+      true_result = subject.for_boolean(true)
+      assert_that(true_result.success?).is_true
+      assert_that(true_result.failure?).is_false
+
+      false_result = subject.for_boolean(false)
+      assert_that(false_result.success?).is_false
+      assert_that(false_result.failure?).is_true
+    end
   end
 
   class InitTests < UnitTests

--- a/test/unit/much-result_tests.rb
+++ b/test/unit/much-result_tests.rb
@@ -71,17 +71,26 @@ class MuchResult
           backtrace: backtrace1,
           value: value1
         )
+      assert_that(result.identifier).equals(identifier1)
       assert_that(result.items.first.identifier).equals(identifier1)
       assert_that(result.description).equals(description1)
       assert_that(result.items.first.description).equals(description1)
       assert_that(result.backtrace).equals(backtrace1)
       assert_that(result.items.first.backtrace).equals(backtrace1)
+      assert_that(result.value).equals(value1)
       assert_that(result.items.first.value).equals(value1)
 
       exception = result.result_exception
       assert_that(exception).is_instance_of(MuchResult::Error)
       assert_that(exception.message).equals(description1)
       assert_that(exception.backtrace).equals(backtrace1)
+    end
+
+    should "allow setting arbitrary values" do
+      assert_that(subject.other_value).is_nil
+
+      subject.set(other_value: value1)
+      assert_that(subject.other_value).equals(value1)
     end
   end
 end


### PR DESCRIPTION
This is the basic API for creating results. MuchResults aggregate
result _items_. These are the building blocks for all other
MuchResult features to come.

# Other Changes

### add MuchResult#set API for setting arbitrary values on results

This allows MuchResults to both take arbitrary values on init and
set additional arbitrary values post-init. This emulates the same
behavior in MuchResult::Item (that OpenStruct provides for free).

The goal is feature parity between MuchResult and MuchResult::Item.

### add `MuchResult.for_boolean` 

This factory method creates SUCCESS results if given `true` and
creates FAILURE results if given `false`. The goal is to help 
convert operations that return a truthy value on success and a 
false-y value on failure to use Result objects.