### PR TITLE
add MuchResult#capture, MuchResult#capture!, and MuchResult.tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Have services/methods return a MuchResult based on the whether an exception was 
 class PerformSomeOperation
   def self.call
     # Do something that could fail by raising an exception.
-    MuchResult.success(value: "it worked!")
+    MuchResult.success(message: "it worked!")
   rescue => exception
     MuchResult.failure(exception: exception)
   end
@@ -21,47 +21,76 @@ result = PerformSomeOperation.call
 result.success? # => true
 result.failure? # => false
 result.items    # => [<MuchResult::Item ...>]
-result.value    # => "it worked!"
+result.message  # => "it worked!"
 ```
 
-Have services/methods return a MuchResult based on a result value:
+Have services/methods return a MuchResult based on a result message:
 
 ```ruby
 def perform_some_operation(success:)
   # Do something that could fail.
-  MuchResult.for(success, value: "some value")
+  MuchResult.for(success, message: "it ran :shrug:")
 end
 
 result = perform_some_operation(success: true)
 result.success? # => true
 result.failure? # => false
 result.items    # => [<MuchResult::Item ...>]
-result.value    # => "some value"
+result.message  # => "it ran :shrug:"
 
 result = perform_some_operation(success: false)
 result.success? # => false
 result.failure? # => true
 result.items    # => [<MuchResult::Item ...>]
-result.value    # => "some value"
+result.message  # => "it ran :shrug:"
 
 result = perform_some_operation(success: nil)
 result.success? # => false
 result.failure? # => true
 result.items    # => [<MuchResult::Item ...>]
-result.value    # => "some value"
+result.message  # => "it ran :shrug:"
 ```
 
 Set arbitrary values on MuchResults before or after they are created:
 
 ```ruby
-result = MuchResult.success(value: "it worked!")
-
+result = MuchResult.success(message: "it worked!")
 result.set(
   other_value1: "something else 1",
   other_value2: "something else 2"
 )
+result.message      # => "it worked!"
 result.other_value1 # => "something else 1"
 result.other_value2 # => "something else 2"
+```
+
+
+Capture MuchResults for sub-operations into a parent MuchResult:
+
+```ruby
+class PerformSomeOperation
+  def self.call
+    MuchResult.tap { |result|
+      # result.success? # => true
+
+      result.capture  { do_part_1 }
+      result.capture! { do_part_2 } # raise an Exception if failure
+
+      # set some arbitrary values b/c it worked.
+      result.set(message: "it worked!")
+    } # => <MuchResult ...>
+  end
+
+  def self.do_part_1
+    # Do something that could fail.
+    MuchResult.for(success, description: "Part 1")
+  end
+
+  def self.do_part_1
+    # Do something that could fail.
+    MuchResult.for(success, description: "Part 2")
+  end
+end
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -4,21 +4,57 @@ API for managing the results of operations.
 
 ## Usage
 
+Have services/methods return a MuchResult based on the whether an exception was raised or not:
 
 ```ruby
-def perform_some_operation
-  # Do something that could fail by raising an exception.
-  MuchResult.success(value: "it worked!")
-rescue => error
-  MuchResult.failure(exception: error)
+class PerformSomeOperation
+  def self.call
+    # Do something that could fail by raising an exception.
+    MuchResult.success(value: "it worked!")
+  rescue => exception
+    MuchResult.failure(exception: exception)
+  end
 end
 
-result = perform_some_operation
+result = PerformSomeOperation.call
 
 result.success? # => true
 result.failure? # => false
 result.items    # => [<MuchResult::Item ...>]
 result.value    # => "it worked!"
+```
+
+Have services/methods return a MuchResult based on a result value:
+
+```ruby
+def perform_some_operation(success:)
+  # Do something that could fail.
+  MuchResult.for(success, value: "some value")
+end
+
+result = perform_some_operation(success: true)
+result.success? # => true
+result.failure? # => false
+result.items    # => [<MuchResult::Item ...>]
+result.value    # => "some value"
+
+result = perform_some_operation(success: false)
+result.success? # => false
+result.failure? # => true
+result.items    # => [<MuchResult::Item ...>]
+result.value    # => "some value"
+
+result = perform_some_operation(success: nil)
+result.success? # => false
+result.failure? # => true
+result.items    # => [<MuchResult::Item ...>]
+result.value    # => "some value"
+```
+
+Set arbitrary values on MuchResults before or after they are created:
+
+```ruby
+result = MuchResult.success(value: "it worked!")
 
 result.set(
   other_value1: "something else 1",

--- a/lib/much-result.rb
+++ b/lib/much-result.rb
@@ -29,6 +29,12 @@ class MuchResult
     }
   end
 
+  def self.tap(backtrace: caller, **kargs)
+    new(backtrace: backtrace, **kargs).tap { |result|
+      yield result if block_given?
+    }
+  end
+
   attr_reader :description, :backtrace
 
   def initialize(description: nil, backtrace: caller, **kargs)
@@ -57,8 +63,22 @@ class MuchResult
     self
   end
 
+  def capture(backtrace: caller, **kargs)
+    self.class.for(
+      (yield if block_given?),
+      backtrace: backtrace,
+      **kargs
+    ).tap { |result| add_item(result) }
+  end
+
+  def capture!(backtrace: caller, **kargs, &block)
+    capture(backtrace: caller, **kargs, &block).tap { |result|
+      raise(result_exception) if result.failure?
+    }
+  end
+
   def add_item(item)
-    @result_items.push(item)
+    @result_items.push(item).tap { reset_result_items_cache }
   end
 
   def result_exception
@@ -73,14 +93,21 @@ class MuchResult
   end
 
   def success_items
-    @success_items || @result_items.flat_map { |item| item.success_items }
+    @success_items ||= @result_items.flat_map { |item| item.success_items }
   end
 
   def failure_items
-    @failure_items || @result_items.flat_map { |item| item.failure_items }
+    @failure_items ||= @result_items.flat_map { |item| item.failure_items }
   end
 
   private
+
+  def reset_result_items_cache
+    @success_predicate = nil
+    @items = nil
+    @success_items = nil
+    @failure_items = nil
+  end
 
   def respond_to_missing?(*args)
     @data.send(:respond_to_missing?, *args)

--- a/lib/much-result.rb
+++ b/lib/much-result.rb
@@ -19,10 +19,12 @@ class MuchResult
     }
   end
 
-  def self.for_boolean(value, backtrace: caller, **kargs)
+  def self.for(value, backtrace: caller, **kargs)
+    return value.set(**kargs) if value.kind_of?(MuchResult)
+
     new(backtrace: backtrace, **kargs).tap { |result|
       result.add_item(
-        MuchResult::Item.for_boolean(value, backtrace: backtrace, **kargs)
+        MuchResult::Item.for(value, backtrace: backtrace, **kargs)
       )
     }
   end
@@ -52,6 +54,7 @@ class MuchResult
 
   def set(**kargs)
     @data = ::OpenStruct.new((@data || {}).to_h.merge(**kargs))
+    self
   end
 
   def add_item(item)

--- a/lib/much-result/item.rb
+++ b/lib/much-result/item.rb
@@ -10,10 +10,10 @@ class MuchResult::Item < ::OpenStruct
     new(**kargs, result: MuchResult::FAILURE, backtrace: backtrace)
   end
 
-  def self.for_boolean(value, backtrace: caller, **kargs)
+  def self.for(value, backtrace: caller, **kargs)
     new(
       **kargs,
-      result: value ? MuchResult::SUCCESS : MuchResult::FAILURE,
+      result: !!value ? MuchResult::SUCCESS : MuchResult::FAILURE,
       backtrace: backtrace
     )
   end

--- a/test/unit/item_tests.rb
+++ b/test/unit/item_tests.rb
@@ -13,7 +13,7 @@ class MuchResult::Item
     let(:backtrace1) { Factory.backtrace }
     let(:value1) { Factory.value }
 
-    should have_imeths :success, :failure
+    should have_imeths :success, :failure, :for
 
     should "build success instances" do
       item = subject.success
@@ -37,6 +37,28 @@ class MuchResult::Item
       assert_that(item.items).equals([item])
       assert_that(item.success_items).equals([])
       assert_that(item.failure_items).equals(item.items)
+    end
+
+    should "build instances based on given values" do
+      true_result = subject.for(true, value: value1)
+      assert_that(true_result.success?).is_true
+      assert_that(true_result.failure?).is_false
+      assert_that(true_result.value).equals(value1)
+
+      false_result = subject.for(false, value: value1)
+      assert_that(false_result.success?).is_false
+      assert_that(false_result.failure?).is_true
+      assert_that(false_result.value).equals(value1)
+
+      value1_result = subject.for(value1, value: value1)
+      assert_that(value1_result.success?).is_true
+      assert_that(value1_result.failure?).is_false
+      assert_that(value1_result.value).equals(value1)
+
+      nil_result = subject.for(nil, value: value1)
+      assert_that(nil_result.success?).is_false
+      assert_that(nil_result.failure?).is_true
+      assert_that(nil_result.value).equals(value1)
     end
   end
 

--- a/test/unit/much-result_tests.rb
+++ b/test/unit/much-result_tests.rb
@@ -24,7 +24,7 @@ class MuchResult
     let(:backtrace1) { Factory.backtrace }
     let(:value1) { Factory.value }
 
-    should have_imeths :success, :failure
+    should have_imeths :success, :failure, :for
 
     should "build success instances" do
       result = subject.success
@@ -48,14 +48,30 @@ class MuchResult
       assert_that(result.failure_items).equals(result.items)
     end
 
-    should "build instances based on a Boolean result" do
-      true_result = subject.for_boolean(true)
+    should "build instances based on given values" do
+      true_result = subject.for(true, value: value1)
       assert_that(true_result.success?).is_true
       assert_that(true_result.failure?).is_false
+      assert_that(true_result.value).equals(value1)
 
-      false_result = subject.for_boolean(false)
+      false_result = subject.for(false, value: value1)
       assert_that(false_result.success?).is_false
       assert_that(false_result.failure?).is_true
+      assert_that(false_result.value).equals(value1)
+
+      value1_result = subject.for(value1, value: value1)
+      assert_that(value1_result.success?).is_true
+      assert_that(value1_result.failure?).is_false
+      assert_that(value1_result.value).equals(value1)
+
+      nil_result = subject.for(nil, value: value1)
+      assert_that(nil_result.success?).is_false
+      assert_that(nil_result.failure?).is_true
+      assert_that(nil_result.value).equals(value1)
+
+      result_result = subject.for(true_result, value: value1)
+      assert_that(result_result).is_the_same_as(true_result)
+      assert_that(result_result.value).equals(value1)
     end
   end
 


### PR DESCRIPTION
The `#capture*` method allow for capturing child MuchResults and
composing them as part of a parent MuchResult. Said another way:
they allow you to aggregate MuchResults.

The `.tap` method is a convenience shortcut yielding a parent
result to a block so child results can be captured. It is a
macro for `MuchResult.new(...).tap { ... }`.

# Other Changes

### `MuchResult.for_boolean` -> `MuchResult.for`

This reworks the `.for_boolean` factory method to be a bit more
generic and just take any value and convert it to a boolean that
means success/failure. This expands the cases where this conversion
method can be used.

This also adds handling so that if `.for` is given a MuchResult,
it just updates its values and returns it.