### PR TITLE
add MuchResult.transaction and MuchResult::Transaction handling

### DIFF
--- a/lib/much-result.rb
+++ b/lib/much-result.rb
@@ -1,11 +1,13 @@
 require "much-result/version"
 require "much-result/item"
+require "much-result/transaction"
 
 class MuchResult
   SUCCESS = "success".freeze
   FAILURE = "failure".freeze
 
-  Error = Class.new(StandardError)
+  Error    = Class.new(StandardError)
+  Rollback = Class.new(RuntimeError)
 
   def self.success(backtrace: caller, **kargs)
     new(backtrace: backtrace, **kargs).tap { |result|
@@ -33,6 +35,10 @@ class MuchResult
     new(backtrace: backtrace, **kargs).tap { |result|
       yield result if block_given?
     }
+  end
+
+  def self.transaction(receiver, backtrace: caller, **kargs, &block)
+    MuchResult::Transaction.call(receiver, backtrace: backtrace, **kargs, &block)
   end
 
   attr_reader :description, :backtrace

--- a/lib/much-result/transaction.rb
+++ b/lib/much-result/transaction.rb
@@ -1,0 +1,41 @@
+require "much-result"
+
+class MuchResult; end
+class MuchResult::Transaction
+  def self.call(receiver, **result_kargs, &block)
+    new(receiver, **result_kargs).call(&block)
+  end
+
+  def initialize(receiver, **result_kargs)
+    @receiver = receiver
+    @result_kargs = result_kargs
+  end
+
+  def result
+    @result ||= MuchResult.new(**@result_kargs)
+  end
+
+  def call(&block)
+    begin
+      @receiver.transaction { block.call(self) }
+    rescue MuchResult::Rollback
+      # do nothing
+    end
+
+    result
+  end
+
+  def rollback
+    raise MuchResult::Rollback
+  end
+
+  private
+
+  def respond_to_missing?(*args)
+    result.send(:respond_to_missing?, *args)
+  end
+
+  def method_missing(method, *args, &block)
+    result.public_send(method, *args, &block)
+  end
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,4 +1,5 @@
 require "assert/factory"
+require "much-stub/call"
 
 module Factory
   extend Assert::Factory
@@ -9,5 +10,26 @@ module Factory
 
   def self.backtrace
     Factory.integer(3).times.map{ Factory.string }
+  end
+
+  def self.transaction_receiver
+    FakeTransactionReceiver.new
+  end
+
+  class FakeTransactionReceiver
+    attr_reader :last_transaction_call
+
+    def transaction(&block)
+      @rolled_back = false
+      @last_transaction_call = MuchStub::Call.new(&block)
+      block.call
+    rescue => exception
+      @rolled_back = true
+      raise exception
+    end
+
+    def rolled_back?
+      !!@rolled_back
+    end
   end
 end

--- a/test/unit/much-result_tests.rb
+++ b/test/unit/much-result_tests.rb
@@ -24,7 +24,7 @@ class MuchResult
     let(:backtrace1) { Factory.backtrace }
     let(:value1) { Factory.value }
 
-    should have_imeths :success, :failure, :for
+    should have_imeths :success, :failure, :for, :tap, :transaction
 
     should "build success instances" do
       result = subject.success
@@ -84,6 +84,24 @@ class MuchResult
           assert_that(result.items.size).equals(0)
         }
       assert_that(tap_result).is_the_same_as(yielded_result)
+    end
+
+    should "call transactions on a transaction receiver" do
+      MuchStub.on_call(MuchResult::Transaction, :call) { |call|
+        @transaction_call = call
+      }
+
+      receiver1 = Factory.transaction_receiver
+      kargs1 = {
+        backtrace: Factory.backtrace,
+        value: value1
+      }
+      block1 = -> {}
+      subject.transaction(receiver1, **kargs1, &block1)
+
+      assert_that(@transaction_call.pargs).equals([receiver1])
+      assert_that(@transaction_call.kargs).equals(kargs1)
+      assert_that(@transaction_call.block).equals(block1)
     end
   end
 

--- a/test/unit/transaction_tests.rb
+++ b/test/unit/transaction_tests.rb
@@ -1,0 +1,82 @@
+require "assert"
+require "much-result/transaction"
+
+class MuchResult::Transaction
+  class UnitTests < Assert::Context
+    desc "MuchResult::Transaction"
+    subject { unit_class }
+
+    let(:unit_class) { MuchResult::Transaction }
+
+    let(:receiver1) { Factory.transaction_receiver }
+    let(:value1) { Factory.value }
+    let(:kargs1) {
+      { value:  value1 }
+    }
+    let(:block1) {
+      ->(transaction) { transaction.set(block_called: true) }
+    }
+
+    should have_imeths :call
+
+    should "call transactions on a transaction receiver" do
+      MuchStub.tap_on_call(unit_class, :new) { |transaction, new_call|
+        @new_call = new_call
+        MuchStub.on_call(transaction, :call) { |transaction_call|
+          @transaction_call = transaction_call
+        }
+      }
+
+      subject.call(receiver1, **kargs1, &block1)
+
+      assert_that(@new_call.pargs).equals([receiver1])
+      assert_that(@new_call.kargs).equals(kargs1)
+      assert_that(@transaction_call.block).equals(block1)
+    end
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { transaction1 }
+
+    let(:transaction1) { unit_class.new(receiver1, **kargs1) }
+
+    should have_imeths :result, :call, :rollback
+
+    should "know its result" do
+      assert_that(subject.result).is_instance_of(MuchResult)
+      assert_that(subject.result.value).equals(value1)
+    end
+
+    should "delegate result methods to its result" do
+      assert_that(subject.value).equals(subject.result.value)
+      assert_that(subject.success?).equals(subject.result.success?)
+      assert_that(subject.items).equals(subject.result.items)
+    end
+
+    should "call transactions on the transaction receiver" do
+      MuchStub.tap_on_call(block1, :call) { |_, call|
+        @block_call = call
+      }
+
+      result = subject.call(&block1)
+
+      assert_that(result).equals(subject.result)
+      assert_that(subject.block_called).is_true
+      assert_that(@block_call.args).equals([subject])
+      assert_that(receiver1.last_transaction_call.block).is_not_nil
+    end
+
+    should "rollback transactions on the transaction receiver" do
+      assert_that(-> { subject.rollback }).raises(MuchResult::Rollback)
+
+      block1 = ->(transaction) { transaction.rollback }
+      assert_that(-> {subject.call(&block1)}).does_not_raise
+      assert_that(receiver1.rolled_back?).is_true
+
+      block1 = ->(transaction) { raise StandardError }
+      assert_that(-> {subject.call(&block1)}).raises(StandardError)
+      assert_that(receiver1.rolled_back?).is_true
+    end
+  end
+end


### PR DESCRIPTION
This API allows you to perform transactions on a transaction
receiver (e.g. `ActiveRecord::Base`) with MuchResult handling and
interactions.

MuchResult::Transaction is designed to be interacted with as
if it was a MuchResult. It delegates all MuchResult API calls to
its MuchResult. This allows you to capture sub-results in a
transaction and rollback if an exception occurs and/or a sub-result
failure.

The `MuchResult.transaction` method commits the transaction and
returns the transaction MuchResult if no exceptions occur.