### PR TITLE
add `#sub_results`, `#success_sub_results`, and `#failure_sub_results`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ end
 
 result = PerformSomeOperation.call
 
-result.success? # => true
-result.failure? # => false
-result.message  # => "it worked!"
+result.success?    # => true
+result.failure?    # => false
+result.message     # => "it worked!"
+result.sub_results # => []
 ```
 
 Have services/methods return a MuchResult based on a result value (i.e. "truthy" = success; "false-y" = failure):
@@ -96,7 +97,13 @@ result = PerformSomeOperation.call
 
 result.success? # => true
 result.message  # => "it worked!"
-result.results  # => [result, <MuchResult Part 1>, <MuchResult Part 2>]
+
+# Get just the immediate sub-results that were captured for the MuchResult.
+result.sub_results # => [<MuchResult Part 1>, <MuchResult Part 2>]
+
+# Get all MuchResults that make up this MuchResult (including those captured
+# on all recursive sub-results).
+result.all_results # => [result, <MuchResult Part 1>, <MuchResult Part 2>]
 ```
 
 ### Transactions
@@ -145,7 +152,13 @@ result = PerformSomeOperation.call
 
 result.success? # => true
 result.message  # => "it worked!"
-result.results  # => [result, <MuchResult Part 1>, <MuchResult Part 2>]
+
+# Get just the immediate sub-results that were captured for the MuchResult.
+result.sub_results # => [<MuchResult Part 1>, <MuchResult Part 2>]
+
+# Get all MuchResults that make up this MuchResult (including those captured
+# on all recursive sub-results).
+result.all_results # => [result, <MuchResult Part 1>, <MuchResult Part 2>]
 ```
 
 Note: MuchResult::Transactions are designed to delegate to their MuchResult. You can interact with a MuchResult::Transaction as if it were a MuchResult.

--- a/test/unit/much-result_tests.rb
+++ b/test/unit/much-result_tests.rb
@@ -21,9 +21,13 @@ class MuchResult
       assert_that(result.success?).is_true
       assert_that(result.failure?).is_false
 
-      assert_that(result.results).equals([result])
-      assert_that(result.success_results).equals([result])
-      assert_that(result.failure_results).equals([])
+      assert_that(result.sub_results).equals([])
+      assert_that(result.success_sub_results).equals([])
+      assert_that(result.failure_sub_results).equals([])
+
+      assert_that(result.all_results).equals([result])
+      assert_that(result.all_success_results).equals([result])
+      assert_that(result.all_failure_results).equals([])
     end
 
     should "build failure instances" do
@@ -32,9 +36,13 @@ class MuchResult
       assert_that(result.success?).is_false
       assert_that(result.failure?).is_true
 
-      assert_that(result.results).equals([result])
-      assert_that(result.success_results).equals([])
-      assert_that(result.failure_results).equals([result])
+      assert_that(result.sub_results).equals([])
+      assert_that(result.success_sub_results).equals([])
+      assert_that(result.failure_sub_results).equals([])
+
+      assert_that(result.all_results).equals([result])
+      assert_that(result.all_success_results).equals([])
+      assert_that(result.all_failure_results).equals([result])
     end
 
     should "build instances based on given values" do
@@ -70,7 +78,8 @@ class MuchResult
           yielded_result = result
 
           assert_that(result.success?).is_true
-          assert_that(result.results.size).equals(1)
+          assert_that(result.sub_results.size).equals(0)
+          assert_that(result.all_results.size).equals(1)
         }
       assert_that(tap_result).is_the_same_as(yielded_result)
     end
@@ -103,7 +112,8 @@ class MuchResult
     should have_imeths :description, :backtrace, :set
     should have_imeths :success?, :failure?
     should have_imeths :capture, :capture!, :result_exception
-    should have_imeths :results, :success_results, :failure_results
+    should have_imeths :sub_results, :success_sub_results, :failure_sub_results
+    should have_imeths :all_results, :all_success_results, :all_failure_results
 
     should "know its attributes" do
       assert_that(subject.description).is_nil
@@ -138,42 +148,60 @@ class MuchResult
     should "allow capturing other MuchResults as results" do
       subject.capture { unit_class.success }
       assert_that(subject.success?).is_true
-      assert_that(subject.results.size).equals(2)
-      assert_that(subject.success_results.size).equals(2)
-      assert_that(subject.failure_results.size).equals(0)
+      assert_that(subject.sub_results.size).equals(1)
+      assert_that(subject.success_sub_results.size).equals(1)
+      assert_that(subject.failure_sub_results.size).equals(0)
+      assert_that(subject.all_results.size).equals(2)
+      assert_that(subject.all_success_results.size).equals(2)
+      assert_that(subject.all_failure_results.size).equals(0)
 
       subject.capture { unit_class.failure }
       assert_that(subject.success?).is_false
-      assert_that(subject.results.size).equals(3)
-      assert_that(subject.success_results.size).equals(1)
-      assert_that(subject.failure_results.size).equals(2)
+      assert_that(subject.sub_results.size).equals(2)
+      assert_that(subject.success_sub_results.size).equals(1)
+      assert_that(subject.failure_sub_results.size).equals(1)
+      assert_that(subject.all_results.size).equals(3)
+      assert_that(subject.all_success_results.size).equals(1)
+      assert_that(subject.all_failure_results.size).equals(2)
 
       result = unit_class.success
       result.capture { [true, Factory.integer, Factory.string].sample }
       assert_that(result.success?).is_true
-      assert_that(result.results.size).equals(2)
-      assert_that(result.success_results.size).equals(2)
-      assert_that(result.failure_results.size).equals(0)
+      assert_that(result.sub_results.size).equals(1)
+      assert_that(result.success_sub_results.size).equals(1)
+      assert_that(result.failure_sub_results.size).equals(0)
+      assert_that(result.all_results.size).equals(2)
+      assert_that(result.all_success_results.size).equals(2)
+      assert_that(result.all_failure_results.size).equals(0)
 
       result.capture { [false, nil].sample }
       assert_that(result.success?).is_false
-      assert_that(result.results.size).equals(3)
-      assert_that(result.success_results.size).equals(1)
-      assert_that(result.failure_results.size).equals(2)
+      assert_that(result.sub_results.size).equals(2)
+      assert_that(result.success_sub_results.size).equals(1)
+      assert_that(result.failure_sub_results.size).equals(1)
+      assert_that(result.all_results.size).equals(3)
+      assert_that(result.all_success_results.size).equals(1)
+      assert_that(result.all_failure_results.size).equals(2)
 
       result = unit_class.success
       result.capture! { unit_class.success }
       assert_that(result.success?).is_true
-      assert_that(result.results.size).equals(2)
-      assert_that(result.success_results.size).equals(2)
-      assert_that(result.failure_results.size).equals(0)
+      assert_that(result.sub_results.size).equals(1)
+      assert_that(result.success_sub_results.size).equals(1)
+      assert_that(result.failure_sub_results.size).equals(0)
+      assert_that(result.all_results.size).equals(2)
+      assert_that(result.all_success_results.size).equals(2)
+      assert_that(result.all_failure_results.size).equals(0)
 
       assert_that(-> { result.capture! { unit_class.failure } }).
         raises(MuchResult::Error)
       assert_that(result.success?).is_false
-      assert_that(result.results.size).equals(3)
-      assert_that(result.success_results.size).equals(1)
-      assert_that(result.failure_results.size).equals(2)
+      assert_that(result.sub_results.size).equals(2)
+      assert_that(result.success_sub_results.size).equals(1)
+      assert_that(result.failure_sub_results.size).equals(1)
+      assert_that(result.all_results.size).equals(3)
+      assert_that(result.all_success_results.size).equals(1)
+      assert_that(result.all_failure_results.size).equals(2)
     end
   end
 end


### PR DESCRIPTION
These methods give options for investigating the _immediate_
MuchResults that make up a MuchResult. These differ from the
`all_*results` methods which recursively return all of the
MuchResults for a MuchResult (including the MuchResult itself plus
all of the recursive sub-results from sub-results).

Note: I renamed the `all_*results` methods to better differentiate
them from the `*sub_results` methods.