### PR TITLE
add MuchResult::Transaction#halt for halting Transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,12 @@ class PerformSomeOperation
       transaction.capture! { do_part_2 }
 
       # manually rollback the transaction if needed
+      # (stops processing and doesn't commit the transaction)
       transaction.rollback if rollback_needed?
+
+      # manually halt the transaction if needed
+      # (stops processing and commits the transaction)
+      transaction.halt if halt_needed?
 
       # set some arbitrary values b/c it worked.
       transaction.set(message: "it worked!")

--- a/test/unit/much-result_tests.rb
+++ b/test/unit/much-result_tests.rb
@@ -101,6 +101,18 @@ class MuchResult
       assert_that(@transaction_call.kargs).equals(kargs1)
       assert_that(@transaction_call.block).equals(block1)
     end
+
+    should "halt transactions" do
+      receiver1 = Factory.transaction_receiver
+      result =
+        subject.transaction(receiver1) do |transaction|
+          transaction.capture { "something1"}
+          transaction.halt
+          transaction.capture { "something2" }
+        end
+
+      assert_that(result.sub_results.size).equals(1)
+    end
   end
 
   class InitTests < UnitTests


### PR DESCRIPTION
This method will, for whatever reason, halt a transaction and
stop processing. Processing resumes at the end of the transaction
block and behaves and returns a MuchResult as expected.