### PR TITLE
add MuchResult::Aggregate; add MuchResult#get_for_*_results

### DIFF
--- a/lib/much-result.rb
+++ b/lib/much-result.rb
@@ -1,4 +1,5 @@
 require "much-result/version"
+require "much-result/aggregate"
 require "much-result/transaction"
 
 class MuchResult
@@ -115,6 +116,30 @@ class MuchResult
     @all_failure_results ||=
       [*(self if failure?)] +
       @sub_results.flat_map { |result| result.all_failure_results }
+  end
+
+  def get_for_sub_results(attribute_name)
+    MuchResult::Aggregate.(sub_results.map(&attribute_name.to_sym))
+  end
+
+  def get_for_success_sub_results(attribute_name)
+    MuchResult::Aggregate.(success_sub_results.map(&attribute_name.to_sym))
+  end
+
+  def get_for_failure_sub_results(attribute_name)
+    MuchResult::Aggregate.(failure_sub_results.map(&attribute_name.to_sym))
+  end
+
+  def get_for_all_results(attribute_name)
+    MuchResult::Aggregate.(all_results.map(&attribute_name.to_sym))
+  end
+
+  def get_for_all_success_results(attribute_name)
+    MuchResult::Aggregate.(all_success_results.map(&attribute_name.to_sym))
+  end
+
+  def get_for_all_failure_results(attribute_name)
+    MuchResult::Aggregate.(all_failure_results.map(&attribute_name.to_sym))
   end
 
   def to_much_result(backtrace: caller, **kargs)

--- a/lib/much-result/aggregate.rb
+++ b/lib/much-result/aggregate.rb
@@ -1,0 +1,57 @@
+require "much-result"
+
+class MuchResult; end
+class MuchResult::Aggregate
+  def self.call(values)
+    new(values).call
+  end
+
+  def initialize(values)
+    @values = values
+  end
+
+  def call
+    combine_values(@values)
+  end
+
+  private
+
+  def combine_values(values)
+    combine_in_a_collection(array_wrap(values))
+  end
+
+  def combine_in_a_collection(values)
+    if all_hash_values?(values)
+      values.
+        reduce { |acc, value| combine_in_a_hash(acc, value) }.
+        transform_values { |nested_values| combine_values(nested_values) }
+    else
+      array_wrap(
+        values.reduce([]) { |acc, value| combine_in_an_array(acc, value) }
+      )
+    end
+  end
+
+  def combine_in_a_hash(hash1, hash2)
+    ((h1 = hash1 || {}).keys + (h2 = hash2 || {}).keys).
+      uniq.
+      reduce({}) { |hash, key|
+        hash[key] = combine_in_an_array(h1[key], h2[key])
+        hash
+      }
+  end
+
+  def combine_in_an_array(acc, other)
+    array_wrap(acc) + array_wrap(other)
+  end
+
+  def array_wrap(value)
+    value.kind_of?(Array) ? value : [value]
+  end
+
+  def all_hash_values?(values)
+    (compacted = values.compact).reduce(compacted.any?) { |acc, value|
+      acc && value.kind_of?(::Hash)
+    }
+  end
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -8,8 +8,15 @@ module Factory
     [Factory.integer, Factory.string, Object.new].sample
   end
 
+  def self.hash_value(with_nested_hash = true)
+    {
+      value1: Factory.value,
+      value2: with_nested_hash ? Factory.hash_value(false) : Factory.value
+    }
+  end
+
   def self.backtrace
-    Factory.integer(3).times.map{ Factory.string }
+    Factory.integer(3).times.map{ Factory.path }
   end
 
   def self.transaction_receiver

--- a/test/unit/aggregate_tests.rb
+++ b/test/unit/aggregate_tests.rb
@@ -1,0 +1,103 @@
+require "assert"
+require "much-result/aggregate"
+
+class MuchResult::Aggregate
+  class UnitTests < Assert::Context
+    desc "MuchResult::Aggregate"
+    subject { unit_class }
+
+    let(:unit_class) { MuchResult::Aggregate }
+
+    let(:values1) {
+      [Factory.value, Factory.value, Factory.value, Hash.new]
+    }
+    let(:hash_values1) {
+      [Factory.hash_value, Factory.hash_value, Factory.hash_value]
+    }
+
+    should have_imeths :call
+
+    should "build instances and call them" do
+      Assert.stub_tap_on_call(subject, :new) { |instance, call|
+        @instance_new_call = call
+        Assert.stub(instance, :call) { @instance_called = true }
+      }
+
+      subject.call(values1)
+
+      assert_that(@instance_new_call.args).equals([values1])
+      assert_that(@instance_called).is_true
+    end
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new(init_values) }
+
+    let(:init_values) { [values1, hash_values1, [], nil].sample }
+
+    should have_imeths :call
+  end
+
+  class CalledWithAnEmptyArrayTests < InitTests
+    desc "and called with an empty Array"
+
+    let(:init_values) { [] }
+    # let(:init_values) { [[], nil, [nil, nil]].sample }
+
+    should "return an empty Array" do
+      assert_that(subject.call).equals([])
+    end
+  end
+
+  class CalledWithASingleNonHashValueTests < InitTests
+    desc "and called with single non-Hash value"
+
+    let(:init_values) { [Factory.value, nil].sample }
+
+    should "return the value wrapped in an Array" do
+      assert_that(subject.call).equals([init_values])
+    end
+  end
+
+  class CalledWithASingleHashValueTests < InitTests
+    desc "and called with single Hash value"
+
+    let(:value1) { [Factory.value, nil].sample }
+    let(:init_values) { { value: value1 } }
+
+    should "return the Hash with its values wrapped in an Array" do
+      assert_that(subject.call).equals(value: [value1])
+    end
+  end
+
+  class CalledWithAMixedValueArrayTests < InitTests
+    desc "and called with a mixed-value Array"
+
+    let(:init_values) { [nil, values1, [], { value: 1 }, nil] }
+
+    should "combines the values into an Array, flattening any sub-Arrays" do
+      assert_that(subject.call).equals([nil, *values1, { value: 1 }, nil])
+    end
+  end
+
+  class CalledWithAnAllHashValueArrayTests < InitTests
+    desc "and called with an all-Hash-value Array"
+
+    let(:init_values) { [nil] + hash_values1 + [nil] }
+
+    let(:expected_aggregate_value) {
+      {
+        value1: init_values.map { |hash| (hash || {})[:value1] },
+        value2: {
+          value1: init_values.map { |hash| (hash || {}).dig(:value2, :value1) },
+          value2: init_values.map { |hash| (hash || {}).dig(:value2, :value2) }
+        }
+      }
+    }
+
+    should "recursively combine the hash values, removing any nils" do
+      assert_that(subject.call).equals(expected_aggregate_value)
+    end
+  end
+end

--- a/test/unit/much-result_tests.rb
+++ b/test/unit/much-result_tests.rb
@@ -124,6 +124,10 @@ class MuchResult
     should have_imeths :capture, :capture!, :capture_exception
     should have_imeths :sub_results, :success_sub_results, :failure_sub_results
     should have_imeths :all_results, :all_success_results, :all_failure_results
+    should have_imeths :get_for_sub_results
+    should have_imeths :get_for_success_sub_results, :get_for_failure_sub_results
+    should have_imeths :get_for_all_results
+    should have_imeths :get_for_all_success_results, :get_for_all_failure_results
     should have_imeths :to_much_result
 
     should "know its attributes" do
@@ -157,23 +161,73 @@ class MuchResult
     end
 
     should "allow capturing other MuchResults as results" do
-      subject.capture { unit_class.success }
+      subject.capture { unit_class.success(values: { value1: Factory.value }) }
       assert_that(subject.success?).is_true
       assert_that(subject.sub_results.size).equals(1)
       assert_that(subject.success_sub_results.size).equals(1)
       assert_that(subject.failure_sub_results.size).equals(0)
+      assert_that(subject.get_for_sub_results("values")[:value1]).equals(
+        [
+          subject.success_sub_results.first.values[:value1]
+        ])
+      assert_that(subject.get_for_success_sub_results("values")[:value1]).equals(
+        [
+          subject.success_sub_results.first.values[:value1]
+        ])
+      assert_that(subject.get_for_failure_sub_results("values")).equals(
+        [])
       assert_that(subject.all_results.size).equals(2)
       assert_that(subject.all_success_results.size).equals(2)
       assert_that(subject.all_failure_results.size).equals(0)
+      assert_that(subject.get_for_all_results("values")[:value1]).equals(
+        [
+          nil,
+          subject.success_sub_results.first.values[:value1]
+        ])
+      assert_that(subject.get_for_all_success_results("values")[:value1]).equals(
+        [
+          nil,
+          subject.success_sub_results.first.values[:value1]
+        ])
+      assert_that(subject.get_for_all_failure_results("values")).equals(
+        [])
 
-      subject.capture { unit_class.failure }
+      subject.capture { unit_class.failure(values: { value1: Factory.value }) }
       assert_that(subject.success?).is_false
       assert_that(subject.sub_results.size).equals(2)
       assert_that(subject.success_sub_results.size).equals(1)
       assert_that(subject.failure_sub_results.size).equals(1)
+      assert_that(subject.get_for_sub_results("values")[:value1]).equals(
+        [
+          subject.success_sub_results.first.values[:value1],
+          subject.failure_sub_results.first.values[:value1]
+        ])
+      assert_that(subject.get_for_success_sub_results("values")[:value1]).equals(
+        [
+          subject.success_sub_results.first.values[:value1]
+        ])
+      assert_that(subject.get_for_failure_sub_results("values")[:value1]).equals(
+        [
+          subject.failure_sub_results.first.values[:value1]
+        ])
       assert_that(subject.all_results.size).equals(3)
       assert_that(subject.all_success_results.size).equals(1)
       assert_that(subject.all_failure_results.size).equals(2)
+      assert_that(subject.get_for_all_results("values")[:value1]).equals(
+        [
+          nil,
+          subject.success_sub_results.first.values[:value1],
+          subject.failure_sub_results.first.values[:value1]
+        ])
+      assert_that(subject.get_for_all_success_results("values")[:value1]).equals(
+        [
+          subject.success_sub_results.first.values[:value1]
+        ])
+      assert_that(subject.get_for_all_failure_results("values")[:value1]).equals(
+        [
+          nil,
+          subject.failure_sub_results.first.values[:value1]
+        ])
 
       result = unit_class.success
       result.capture { [true, Factory.integer, Factory.string].sample }


### PR DESCRIPTION
This adds get methods for accessing aggregate values on results in
a MuchResult. Nested Hash values are recursively aggregated at
their leaf values. Any single values are transformed into a
collection (both top level and nested Hash values).

Note: `nil` values aren't compacted away in the aggregate
collections. This is so aggregate values line up 1-to-1 with their
corresponding result in the aggregated result-set. 
