### PR TITLE
add MuchResult#to_much_result; use in MuchResult.for

### DIFF
--- a/lib/much-result.rb
+++ b/lib/much-result.rb
@@ -17,7 +17,9 @@ class MuchResult
   end
 
   def self.for(value, backtrace: caller, **kargs)
-    return value.set(**kargs) if value.kind_of?(MuchResult)
+    if value.respond_to?(:to_much_result)
+      return value.to_much_result(**kargs, backtrace: backtrace)
+    end
 
     new(
       !!value ? MuchResult::SUCCESS : MuchResult::FAILURE,
@@ -113,6 +115,10 @@ class MuchResult
     @all_failure_results ||=
       [*(self if failure?)] +
       @sub_results.flat_map { |result| result.all_failure_results }
+  end
+
+  def to_much_result(backtrace: caller, **kargs)
+    self.set(**kargs)
   end
 
   def inspect

--- a/test/unit/much-result_tests.rb
+++ b/test/unit/much-result_tests.rb
@@ -66,9 +66,9 @@ class MuchResult
       assert_that(nil_result.failure?).is_true
       assert_that(nil_result.value).equals(value1)
 
-      result_result = subject.for(true_result, value: value1)
+      result_result = subject.for(true_result, value2: value1)
       assert_that(result_result).is_the_same_as(true_result)
-      assert_that(result_result.value).equals(value1)
+      assert_that(result_result.value2).equals(value1)
     end
 
     should "build instances yielded to a given block" do
@@ -124,6 +124,7 @@ class MuchResult
     should have_imeths :capture, :capture!, :capture_exception
     should have_imeths :sub_results, :success_sub_results, :failure_sub_results
     should have_imeths :all_results, :all_success_results, :all_failure_results
+    should have_imeths :to_much_result
 
     should "know its attributes" do
       assert_that(subject.description).is_nil
@@ -233,6 +234,14 @@ class MuchResult
       assert_that(result.all_results.size).equals(4)
       assert_that(result.all_success_results.size).equals(1)
       assert_that(result.all_failure_results.size).equals(3)
+    end
+
+    should "convert itself to a MuchResult" do
+      assert_that(subject.value).is_nil
+
+      result = subject.to_much_result(value: value1)
+      assert_that(result).is_the_same_as(subject)
+      assert_that(subject.value).equals(value1)
     end
   end
 end


### PR DESCRIPTION
This switches `MuchResult.for` to check for a `to_much_result`
conversion method on the `value` and prefer using it if so. This
allows individual object types to each define how they are
converted to MuchResults and allows expanding better to new types.

This also adds a `#to_much_result` conversion method for
MuchResults themselves.