### PR TITLE
have Transactions set rollback/halt state data on their Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ result = PerformSomeOperation.call
 result.success? # => true
 result.message  # => "it worked!"
 
+result.much_result_transaction_rolled_back # => false
+result.much_result_transaction_halted      # => false
+
 # Get just the immediate sub-results that were captured for the MuchResult.
 result.sub_results # => [<MuchResult Part 1>, <MuchResult Part 2>]
 

--- a/lib/much-result/transaction.rb
+++ b/lib/much-result/transaction.rb
@@ -13,6 +13,9 @@ class MuchResult::Transaction
   def initialize(receiver, **result_kargs)
     @receiver = receiver
     @result_kargs = result_kargs
+
+    result.much_result_transaction_rolled_back = false
+    result.much_result_transaction_halted = false
   end
 
   def result
@@ -32,10 +35,12 @@ class MuchResult::Transaction
   end
 
   def rollback
+    result.much_result_transaction_rolled_back = true
     raise MuchResult::Rollback
   end
 
   def halt
+    result.much_result_transaction_halted = true
     throw(self.class.halt_throw_value)
   end
 

--- a/test/unit/transaction_tests.rb
+++ b/test/unit/transaction_tests.rb
@@ -48,6 +48,8 @@ class MuchResult::Transaction
     should "know its result" do
       assert_that(subject.result).is_instance_of(MuchResult)
       assert_that(subject.result.value).equals(value1)
+      assert_that(subject.result.much_result_transaction_rolled_back).is_false
+      assert_that(subject.result.much_result_transaction_halted).is_false
     end
 
     should "delegate result methods to its result" do
@@ -79,6 +81,9 @@ class MuchResult::Transaction
       block1 = ->(transaction) { raise StandardError }
       assert_that(-> {subject.call(&block1)}).raises(StandardError)
       assert_that(receiver1.rolled_back?).is_true
+
+      assert_that(subject.result.much_result_transaction_rolled_back).is_true
+      assert_that(subject.result.much_result_transaction_halted).is_false
     end
 
     should "halt transactions" do
@@ -89,6 +94,9 @@ class MuchResult::Transaction
       end
 
       assert_that(subject.sub_results.size).equals(1)
+
+      assert_that(subject.result.much_result_transaction_rolled_back).is_false
+      assert_that(subject.result.much_result_transaction_halted).is_true
     end
   end
 end


### PR DESCRIPTION
This allows the user to introspect the Result of a Transaction to
see if it had been rolled back or halted. This is especially useful
in testing Transaction interactions.