### PR TITLE
rework MuchResult#capture methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ class PerformSomeOperation
       result.success? # => true
 
       result.capture { do_part_1 }
+      # OR you can use `capture_all` to capture from an Array of MuchResults
 
       # raise an Exception if failure
       result.capture! { do_part_2 }
+      # OR you can use `capture_all!` to capture from an Array of MuchResults
 
       # set some arbitrary values b/c it worked.
       result.set(message: "it worked!")
@@ -139,9 +141,11 @@ class PerformSomeOperation
       transaction.success? # => true
 
       transaction.capture { do_part_1 }
+      # OR you can use `capture_all` to capture from an Array of MuchResults
 
       # raise an Exception if failure (which will rollback the transaction)
       transaction.capture! { do_part_2 }
+      # OR you can use `capture_all!` to capture from an Array of MuchResults
 
       # manually rollback the transaction if needed
       # (stops processing and doesn't commit the transaction)


### PR DESCRIPTION
This switches to the following #capture methods:
* `capture_for(...)` captures a given value converted to a result
* `capture_for!(...)` captures a given value converted to a result,
  raising an exception if the result is a failure
* `capture { ... }` captures a result returned by a block call
* `capture! { ... }` captures a result returned by a block call,
  raising an exception if the result is a failure

In addition, this adds `*_all` capture method. These methods, like
their `capture`/`capture!` equivalents, capture MuchResults.
However, these variants expect their results to be in an Array and
capture each result in that Array.

All of this is to provide a rich API for capturing sub-results
that can be used in a variety of different circumstances and
situations to ease using MuchResult.

Note: I also reworked the tests to group them logically so that
adding the new tests had some structure.