### PR TITLE
add MuchResult.default_transaction_receiver handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,18 @@ result.get_for_all_failure_results(:description)
 
 Note: MuchResult::Transactions are designed to delegate to their MuchResult. You can interact with a MuchResult::Transaction as if it were a MuchResult.
 
+You can configure a default transaction receiver (e.g. `ActiveRecord::Base`) in an initializer. Doing so means if no receiver is passed to `MuchResult.transaction`, the default receiver will be used:
+
+```ruby
+# In an initializer or configuration script:
+MuchResult.default_transaction_receiver = ActiveRecord::Base
+
+# Since no receiver is passed, ActiveRecord::Base will be used:
+MuchResult.transaction do |transaction|
+  # ...
+end
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/much-result.rb
+++ b/lib/much-result.rb
@@ -35,8 +35,28 @@ class MuchResult
     }
   end
 
-  def self.transaction(receiver, backtrace: caller, **kargs, &block)
-    MuchResult::Transaction.call(receiver, backtrace: backtrace, **kargs, &block)
+  def self.transaction(receiver = nil, backtrace: caller, **kargs, &block)
+    if (transaction_receiver = receiver || default_transaction_receiver).nil?
+      raise(
+        ArgumentError,
+        "no receiver given and no default_transaction_receiver configured."
+      )
+    end
+
+    MuchResult::Transaction.(
+      receiver || default_transaction_receiver,
+      backtrace: backtrace,
+      **kargs,
+      &block
+    )
+  end
+
+  def self.default_transaction_receiver
+    @default_transaction_receiver
+  end
+
+  def self.default_transaction_receiver=(receiver)
+    @default_transaction_receiver = receiver
   end
 
   attr_reader :sub_results, :description, :backtrace

--- a/lib/much-result/transaction.rb
+++ b/lib/much-result/transaction.rb
@@ -11,6 +11,8 @@ class MuchResult::Transaction
   end
 
   def initialize(receiver, **result_kargs)
+    raise(ArgumentError, "`receiver` can't be nil.") if receiver.nil?
+
     @receiver = receiver
     @result_kargs = result_kargs
 

--- a/test/unit/transaction_tests.rb
+++ b/test/unit/transaction_tests.rb
@@ -45,6 +45,12 @@ class MuchResult::Transaction
 
     should have_imeths :result, :call, :rollback, :halt
 
+    should "complain if given a nil receiver" do
+      assert_that(-> {
+        unit_class.new(nil, **kargs1)
+      }).raises(ArgumentError)
+    end
+
     should "know its result" do
       assert_that(subject.result).is_instance_of(MuchResult)
       assert_that(subject.result.value).equals(value1)


### PR DESCRIPTION
If a default transaction receiver is configured, you can omit
passing a receiver when calling `MuchResult.transaction` and the
default will be used.