### PR TITLE
Improve MuchResult#inspect to enumerate added keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ result.set(
 result.message      # => "it worked!"
 result.other_value1 # => "something else 1"
 result.other_value2 # => "something else 2"
+
+result.attribute_names # => [:message, :other_value1, :other_value2]
+
+result.attributes
+# => {
+#  message: "it worked!",
+#  other_value1: "something else 1",
+#  other_value2: "something else 2"
+# }
 ```
 
 ### Capture sub-Results

--- a/lib/much-result.rb
+++ b/lib/much-result.rb
@@ -77,6 +77,14 @@ class MuchResult
     self
   end
 
+  def attributes
+    @data.to_h.reject { |key, _| key.to_s.start_with?("much_result_") }
+  end
+
+  def attribute_names
+    attributes.keys
+  end
+
   def success?
     if @success_predicate.nil?
       @success_predicate =
@@ -197,7 +205,8 @@ class MuchResult
     "#<#{self.class}:#{"0x0%x" % (object_id << 1)} "\
       "#{success? ? "SUCCESS" : "FAILURE"} "\
       "#{"@description=#{@description.inspect} " if @description}"\
-      "@sub_results=#{@sub_results.inspect}>"
+      "@sub_results=#{@sub_results.inspect} "\
+      "attribute_names: #{attribute_names}>"
   end
 
   private

--- a/test/unit/much-result_tests.rb
+++ b/test/unit/much-result_tests.rb
@@ -157,6 +157,7 @@ class MuchResult
     }
 
     should have_imeths :description, :backtrace, :set
+    should have_imeths :attributes, :attribute_names
     should have_imeths :success?, :failure?
     should have_imeths :capture_for, :capture_for!
     should have_imeths :capture_for_all, :capture_for_all!
@@ -194,11 +195,20 @@ class MuchResult
       assert_that(exception.backtrace).equals(backtrace1)
     end
 
-    should "allow setting arbitrary values" do
+    should "allow setting arbitrary attributes" do
       assert_that(subject.other_value).is_nil
 
       subject.set(other_value: value1)
       assert_that(subject.other_value).equals(value1)
+    end
+
+    should "provide details on dynamically defined attributes" do
+      assert_that(subject.attributes).is_empty
+
+      subject.new_attribute = "new_value"
+
+      assert_that(subject.attributes).equals(new_attribute: "new_value")
+      assert_that(subject.attribute_names).equals([:new_attribute])
     end
 
     should "capture MuchResults as sub-results" do


### PR DESCRIPTION
Improve MuchResult#inspect to enumerate added keys

The goal here is to make it obvious what keys have been added to the
@data OpenStruct when inspecting a MuchResult instance.

Note: As this is meant for the consumer, any internal keys (represented
by a `much_result_` prefix) are removed from the inspected Keys array.

Example:

```ruby

result = MuchResult.success
=> #<MuchResult:0x07fb80d533758 SUCCESS @sub_results=[] @attribute_names: []>

result.numbers = [1, 2]
=> [1, 2]

result
=> #<MuchResult:0x07fb80d533758 SUCCESS @sub_results=[] @attribute_names: [:numbers]>

result.numbers
=> [1, 2]
```

To accomplish this, I've also defined official `#attributes` and
`#attribute_names` methods on MuchResult objects. This allows the
consumer of a result object to interrogate the object for any special
"payload" it may be carrying.

Example:

```ruby
result = MuchResult.success
=> #<MuchResult:0x07f827002f4f0 SUCCESS @sub_results=[] attribute_names: []>

result.attributes
=> {}

result.attribute_names
=> []

result.attr1 = 1
result.attr2 = 2

result.attributes
=> {:attr1=>1, :attr2=>2}

result.attribute_names
=> [:attr1, :attr2]
```